### PR TITLE
Added missing destroy call for fft_settings in benches

### DIFF
--- a/kzg-bench/src/benches/fft.rs
+++ b/kzg-bench/src/benches/fft.rs
@@ -3,9 +3,10 @@ use kzg::{FFTFr, FFTSettings, Fr};
 
 pub fn bench_fft_fr<TFr: Fr, TFFTSettings: FFTSettings<TFr> + FFTFr<TFr>>(c: &mut Criterion) {
     for scale in 4..16 {
-        let fft_settings = TFFTSettings::new(scale as usize).unwrap();
+        let mut fft_settings = TFFTSettings::new(scale as usize).unwrap();
         let data: Vec<TFr> = vec![TFr::rand(); fft_settings.get_max_width()];
         let id = format!("bench_fft_fr scale: '{}'", scale);
         c.bench_function(&id, |b| b.iter(|| fft_settings.fft_fr(&data, false)));
+        fft_settings.destroy();
     }
 }


### PR DESCRIPTION
preserve memory in 16 gb of ram