### PR TITLE
Pass FFTSettings as reference

### DIFF
--- a/Arkworks/src/kzg_proofs.rs
+++ b/Arkworks/src/kzg_proofs.rs
@@ -1,4 +1,6 @@
 #![allow(non_camel_case_types)]
+
+use std::borrow::Borrow;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_poly_commit::kzg10::{
     Commitment, Powers, Proof, Randomness, UniversalParams, VerifierKey, KZG10,
@@ -393,7 +395,7 @@ pub(crate) fn new_kzg_settings(
     secret_g1: &Vec<ArkG1>,
     _secret_g2: &Vec<ArkG2>,
     length: u64,
-    fs: FFTSettings,
+    ffs: &FFTSettings,
 ) -> KZGSettings {
     let (mut params, test, test2) = KZG::<Bls12_381, UniPoly_381>::setup(length as usize, true, &mut test_rng()).unwrap();
     let mut temp = Vec::new();
@@ -423,7 +425,7 @@ pub(crate) fn new_kzg_settings(
         secret_g2: temp2,
         length: length,
         params: params,
-        fs: fs,
+        fs: ffs.borrow().clone(),
         ..Default::default()
     }
 }

--- a/Arkworks/src/kzg_types.rs
+++ b/Arkworks/src/kzg_types.rs
@@ -422,7 +422,7 @@ impl KZGSettings<FsFr, ArkG1, ArkG2, LFFTSettings, LPoly> for LKZGSettings {
         secret_g1: &Vec<ArkG1>,
         secret_g2: &Vec<ArkG2>,
         length: usize,
-        fs: LFFTSettings,
+        fs: &LFFTSettings,
     ) -> Result<LKZGSettings, String> {
         Ok(new_kzg_settings(secret_g1, secret_g2, length as u64, fs))
     }
@@ -460,6 +460,6 @@ impl KZGSettings<FsFr, ArkG1, ArkG2, LFFTSettings, LPoly> for LKZGSettings {
 
 impl Clone for LKZGSettings {
     fn clone(&self) -> Self {
-        LKZGSettings::new(&self.secret_g1.clone(), &self.secret_g2.clone(), self.length as usize, self.fs.clone()).unwrap()
+        LKZGSettings::new(&self.secret_g1.clone(), &self.secret_g2.clone(), self.length as usize, &self.fs.clone()).unwrap()
     }
 }

--- a/ckzg/src/kzgsettings.rs
+++ b/ckzg/src/kzgsettings.rs
@@ -42,10 +42,10 @@ impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly> for KzgKZGSett
         }
     }
 
-    fn new(secret_g1: &Vec<BlstP1>, secret_g2: &Vec<BlstP2>, length: usize, fs: KzgFFTSettings) -> Result<Self, String> {
+    fn new(secret_g1: &Vec<BlstP1>, secret_g2: &Vec<BlstP2>, length: usize, fs: &KzgFFTSettings) -> Result<Self, String> {
         let mut settings = KZGSettings::default();
         unsafe {
-            return match new_kzg_settings(&mut settings, secret_g1.as_ptr(), secret_g2.as_ptr(), length as u64, &fs) {
+            return match new_kzg_settings(&mut settings, secret_g1.as_ptr(), secret_g2.as_ptr(), length as u64, fs) {
                 KzgRet::KzgOk => Ok(settings),
                 e => Err(format!("An error has occurred in KZGSettings::new ==> {:?}", e))
             }
@@ -111,8 +111,8 @@ impl KZGSettings<BlstFr, BlstP1, BlstP2, KzgFFTSettings, KzgPoly> for KzgKZGSett
 
     fn destroy(&mut self) {
         unsafe {
-            let mut ffs = *self.fs as KzgFFTSettings;
-            ffs.destroy();
+            //let mut ffs = *self.fs as KzgFFTSettings;
+            //ffs.destroy();
             free_kzg_settings(self);
         }
     }

--- a/kzg-bench/src/tests/kzg_proofs.rs
+++ b/kzg-bench/src/tests/kzg_proofs.rs
@@ -28,8 +28,8 @@ pub fn proof_single<
 
     // Initialise the secrets and data structures
     let (s1, s2) = generate_trusted_setup(secrets_len, SECRET);
-    let fs = TFFTSettings::new(4).unwrap();
-    let mut ks = TKZGSettings::new(&s1, &s2, secrets_len, fs).unwrap();
+    let mut fs = TFFTSettings::new(4).unwrap();
+    let mut ks = TKZGSettings::new(&s1, &s2, secrets_len, &fs).unwrap();
 
     // Compute the proof for x = 25
     let x = TFr::from_u64(25);
@@ -45,6 +45,7 @@ pub fn proof_single<
     assert!(!ks.check_proof_single(&commitment, &proof, &x, &value).unwrap());
 
     p.destroy();
+    fs.destroy();
     ks.destroy();
 }
 
@@ -63,13 +64,14 @@ pub fn commit_to_nil_poly<
 
         // Initialise the (arbitrary) secrets and data structures
         let (s1, s2) = generate_trusted_setup(secrets_len, SECRET);
-        let fs = TFFTSettings::new(4).unwrap();
-        let mut ks = TKZGSettings::new(&s1, &s2, secrets_len, fs).unwrap();
+        let mut fs = TFFTSettings::new(4).unwrap();
+        let mut ks = TKZGSettings::new(&s1, &s2, secrets_len, &fs).unwrap();
 
         let mut a = TPoly::new(0).unwrap();
         let result = ks.commit_to_poly(&a).unwrap();
         assert!(result.equals(&TG1::default()));
 
+        fs.destroy();
         ks.destroy();
         a.destroy();
     }
@@ -93,13 +95,14 @@ pub fn commit_to_too_long_poly<
 
         // Initialise the (arbitrary) secrets and data structures
         let (s1, s2) = generate_trusted_setup(secrets_len, SECRET);
-        let fs = TFFTSettings::new(4).unwrap();
-        let mut ks = TKZGSettings::new(&s1, &s2, secrets_len, fs).unwrap();
+        let mut fs = TFFTSettings::new(4).unwrap();
+        let mut ks = TKZGSettings::new(&s1, &s2, secrets_len, &fs).unwrap();
 
         let mut a = TPoly::new(poly_len).unwrap();
 
         let _result = ks.commit_to_poly(&a);
 
+        fs.destroy();
         ks.destroy();
         a.destroy();
     }
@@ -141,14 +144,14 @@ pub fn proof_multi<
 
     // Initialise the secrets and data structures
     let (s1, s2) = generate_trusted_setup(secrets_len, SECRET);
-    let fs1 = TFFTSettings::new(4).unwrap();
-    let mut ks1 = TKZGSettings::new(&s1, &s2, secrets_len, fs1).unwrap();
+    let mut fs1 = TFFTSettings::new(4).unwrap();
+    let mut ks1 = TKZGSettings::new(&s1, &s2, secrets_len, &fs1).unwrap();
 
     // Commit to the polynomial
     let commitment = ks1.commit_to_poly(&p).unwrap();
 
-    let fs2 = TFFTSettings::new(coset_scale).unwrap();
-    let mut ks2 = TKZGSettings::new(&s1, &s2, secrets_len, fs2).unwrap();
+    let mut fs2 = TFFTSettings::new(coset_scale).unwrap();
+    let mut ks2 = TKZGSettings::new(&s1, &s2, secrets_len, &fs2).unwrap();
 
     // Compute proof at the points [x * root_i] 0 <= i < coset_len
     let x = TFr::from_u64(5431);
@@ -171,6 +174,8 @@ pub fn proof_multi<
     assert_eq!(result, false);
 
     p.destroy();
+    fs1.destroy();
+    fs2.destroy();
     ks1.destroy();
     ks2.destroy();
 }

--- a/kzg/src/lib.rs
+++ b/kzg/src/lib.rs
@@ -192,7 +192,7 @@ pub trait KZGSettings<
 {
     fn default() -> Self;
 
-    fn new(secret_g1: &Vec<Coeff2>, secret_g2: &Vec<Coeff3>, length: usize, fs: Fs) -> Result<Self, String>;
+    fn new(secret_g1: &Vec<Coeff2>, secret_g2: &Vec<Coeff3>, length: usize, fs: &Fs) -> Result<Self, String>;
 
     fn commit_to_poly(&self, p: &Polynomial) -> Result<Coeff2, String>;
 


### PR DESCRIPTION
because c-kzg passes it as const pointer to FFTSettings:

```c
C_KZG_RET new_kzg_settings(KZGSettings *ks, const g1_t *secret_g1, const g2_t *secret_g2, uint64_t length,
                           const FFTSettings *fs);
```

which implies that the same FFTSettings instance can be reused for different KZGSettings' instances, which at the present moment wasn't possible due to the move being invoked on FFTSettings