### PR TITLE
Fix kzg bench

### DIFF
--- a/ckzg/Cargo.toml
+++ b/ckzg/Cargo.toml
@@ -18,3 +18,7 @@ harness = false
 [[bench]]
 name = "poly"
 harness = false
+
+[[bench]]
+name = "kzg"
+harness = false

--- a/ckzg/benches/kzg.rs
+++ b/ckzg/benches/kzg.rs
@@ -1,0 +1,15 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use kzg_bench::benches::kzg::kzg_proof;
+
+use ckzg::consts::{BlstP1, BlstP2};
+use ckzg::fftsettings::KzgFFTSettings;
+use ckzg::kzgsettings::{generate_trusted_setup, KzgKZGSettings};
+use ckzg::poly::KzgPoly;
+use ckzg::finite::BlstFr;
+
+fn kzg_proof_(c: &mut Criterion) {
+    kzg_proof::<BlstFr, BlstP1, BlstP2, KzgPoly, KzgFFTSettings, KzgKZGSettings>(c, &generate_trusted_setup);
+}
+
+criterion_group!(benches, kzg_proof_);
+criterion_main!(benches);

--- a/kzg-bench/src/benches/kzg.rs
+++ b/kzg-bench/src/benches/kzg.rs
@@ -2,36 +2,29 @@ use criterion::Criterion;
 use kzg::{FFTSettings, Fr, KZGSettings, Poly, G1, G2};
 
 pub const SECRET: [u8; 32usize] = [0xa4, 0x73, 0x31, 0x95, 0x28, 0xc8, 0xb6, 0xea, 0x4d, 0x08, 0xcc,
-                                0x53, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    0x53, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
 pub fn kzg_proof<
-        TFr: Fr,
-        TG1: G1,
-        TG2: G2,
-        TPoly: Poly<TFr>,
-        TFFTSettings: FFTSettings<TFr>,
-        TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly>
+    TFr: Fr,
+    TG1: G1,
+    TG2: G2,
+    TPoly: Poly<TFr>,
+    TFFTSettings: FFTSettings<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly>
 >(
-        generate_trusted_setup: &dyn Fn(usize, [u8; 32usize]) -> (Vec<TG1>, Vec<TG2>),
-        c: &mut Criterion
-) {     
-        for scale in 1..15 {
-        let mut fs = TFFTSettings::new(scale as usize).unwrap();
-        
-        let fssize = fs.get_max_width();
-        let (s1, s2) = generate_trusted_setup(fssize, SECRET);
-        let mut ks = TKZGSettings::new(&s1, &s2, fssize, fs).unwrap();
-
-
-        let mut poly = TPoly::new(fssize).unwrap();
-        for i in 0..fssize {
+    c: &mut Criterion,
+    generate_trusted_setup: &dyn Fn(usize, [u8; 32usize]) -> (Vec<TG1>, Vec<TG2>)
+) {
+    for scale in 1..16 {
+        let fs = TFFTSettings::new(scale as usize).unwrap();
+        let (s1, s2) = generate_trusted_setup(fs.get_max_width(), SECRET);
+        let ks = TKZGSettings::new(&s1, &s2, fs.get_max_width(), &fs).unwrap();
+        let mut poly = TPoly::new(fs.get_max_width()).unwrap();
+        for i in 0..fs.get_max_width() {
             poly.set_coeff_at(i, &TFr::rand());
         }
-        let id = format!("bench_kzg_proof scale: '{}'", scale);
+        let id = format!("bench_commit_to_poly scale: '{}'", scale);
         c.bench_function(&id, |b| b.iter(|| ks.commit_to_poly(&poly).unwrap()));
-
-        ks.destroy();
-        poly.destroy();
     }
 }

--- a/kzg-bench/src/benches/mod.rs
+++ b/kzg-bench/src/benches/mod.rs
@@ -1,3 +1,4 @@
 pub mod fft;
 pub mod poly;
+pub mod kzg;
 pub mod das;


### PR DESCRIPTION
Because:
* it wasn't included in `mod.rs`
* `destroy` methods were made obsolete in #77
* wrong iteration
* wrong `id` string