### PR TITLE
[Mcl]Style fixes alternative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,164 +21,164 @@ jobs:
 
 # 1st team #########################################################
 
-    - name: "[arkworks] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
+    # - name: "[arkworks] Clippy"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: clippy
+    #     args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
 
-    - name: "[arkworks] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path Arkworks/Cargo.toml
+    # - name: "[arkworks] Formatting"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: fmt
+    #     args: --manifest-path Arkworks/Cargo.toml
         
-    - name: "[arkworks] Tests without parallel"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path Arkworks/Cargo.toml
+    # - name: "[arkworks] Tests without parallel"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: test
+    #     args: --manifest-path Arkworks/Cargo.toml
 
-    - name: "[arkworks] Tests with parallel"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path Arkworks/Cargo.toml --features parallel
+    # - name: "[arkworks] Tests with parallel"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: test
+    #     args: --manifest-path Arkworks/Cargo.toml --features parallel
 
-    - name: "[arkworks] Benchmark without parallelization"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path Arkworks/Cargo.toml
+    # - name: "[arkworks] Benchmark without parallelization"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: bench
+    #     args: --manifest-path Arkworks/Cargo.toml
 
-    - name: "[arkworks] Benchmark with parallelization"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path Arkworks/Cargo.toml --features parallel
+    # - name: "[arkworks] Benchmark with parallelization"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: bench
+    #     args: --manifest-path Arkworks/Cargo.toml --features parallel
 
 # 2nd team #########################################################
 
-    - name: "[zkcrypto] Tests"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path zkcrypto/Cargo.toml
+    # - name: "[zkcrypto] Tests"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: test
+    #     args: --manifest-path zkcrypto/Cargo.toml
 
-    - name: "[zkcrypto] Benches"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path zkcrypto/Cargo.toml
+    # - name: "[zkcrypto] Benches"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: bench
+    #     args: --manifest-path zkcrypto/Cargo.toml
 
-    - name: "[zkcrypto] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-       command: clippy
-       args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
+    # - name: "[zkcrypto] Clippy"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #    command: clippy
+    #    args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
 
-    - name: "[zkcrypto] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path zkcrypto/Cargo.toml
+    # - name: "[zkcrypto] Formatting"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: fmt
+    #     args: --manifest-path zkcrypto/Cargo.toml
 
 # 3rd team #########################################################
 
-    - name: "[blst-from-scratch] Tests"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path blst-from-scratch/Cargo.toml
+    # - name: "[blst-from-scratch] Tests"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: test
+    #     args: --manifest-path blst-from-scratch/Cargo.toml
 
-    - name: "[blst-from-scratch] Benchmark"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path blst-from-scratch/Cargo.toml
+    # - name: "[blst-from-scratch] Benchmark"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: bench
+    #     args: --manifest-path blst-from-scratch/Cargo.toml
 
-    - name: "[blst-from-scratch] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-       command: clippy
-       args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
+    # - name: "[blst-from-scratch] Clippy"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #    command: clippy
+    #    args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
 
-    - name: "[blst-from-scratch] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path blst-from-scratch/Cargo.toml
+    # - name: "[blst-from-scratch] Formatting"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: fmt
+    #     args: --manifest-path blst-from-scratch/Cargo.toml
 
 # 4th team #########################################################
 
-    - name: "[ckzg] Build native libs for Linux"
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
-        echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
-        cd ckzg && bash build.sh
+    # - name: "[ckzg] Build native libs for Linux"
+    #   if: matrix.os == 'ubuntu-latest'
+    #   run: |
+    #     echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
+    #     echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
+    #     cd ckzg && bash build.sh
 
-    - name: "[ckzg] Build native libs for MacOS"
-      if: matrix.os == 'macos-11'
-      run: |
-        brew install libomp gnu-sed
-        echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
-        echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
-        cd ckzg && bash build.sh
+    # - name: "[ckzg] Build native libs for MacOS"
+    #   if: matrix.os == 'macos-11'
+    #   run: |
+    #     brew install libomp gnu-sed
+    #     echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
+    #     echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+    #     cd ckzg && bash build.sh
 
-    - name: "[ckzg] Setup Env"
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      run: |
-        if [[ -z "$LIBOMP_PATH" ]]; then
-          echo "FAIL: LLVM OpenMP runtime was not found"
-          exit 1
-        fi
-        echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
+    # - name: "[ckzg] Setup Env"
+    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+    #   run: |
+    #     if [[ -z "$LIBOMP_PATH" ]]; then
+    #       echo "FAIL: LLVM OpenMP runtime was not found"
+    #       exit 1
+    #     fi
+    #     echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
 
-    - name: "[ckzg] Tests without parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: test
-        args: --manifest-path ckzg/Cargo.toml
+    # - name: "[ckzg] Tests without parallelization"
+    #   uses: actions-rs/cargo@v1
+    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+    #   with:
+    #     command: test
+    #     args: --manifest-path ckzg/Cargo.toml
 
-    - name: "[ckzg] Tests with parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: test
-        args: --manifest-path ckzg/Cargo.toml --features parallel
+    # - name: "[ckzg] Tests with parallelization"
+    #   uses: actions-rs/cargo@v1
+    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+    #   with:
+    #     command: test
+    #     args: --manifest-path ckzg/Cargo.toml --features parallel
 
-    - name: "[ckzg] Benchmark without parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: bench
-        args: --manifest-path ckzg/Cargo.toml
+    # - name: "[ckzg] Benchmark without parallelization"
+    #   uses: actions-rs/cargo@v1
+    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+    #   with:
+    #     command: bench
+    #     args: --manifest-path ckzg/Cargo.toml
 
-    - name: "[ckzg] Benchmark with parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: bench
-        args: --manifest-path ckzg/Cargo.toml --features parallel
+    # - name: "[ckzg] Benchmark with parallelization"
+    #   uses: actions-rs/cargo@v1
+    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+    #   with:
+    #     command: bench
+    #     args: --manifest-path ckzg/Cargo.toml --features parallel
 
-    - name: "[ckzg] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
+    # - name: "[ckzg] Clippy"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: clippy
+    #     args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
 
-    - name: "[ckzg] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path ckzg/Cargo.toml
+    # - name: "[ckzg] Formatting"
+    #   uses: actions-rs/cargo@v1
+    #   with:
+    #     command: fmt
+    #     args: --manifest-path ckzg/Cargo.toml
 
-    - name: "[ckzg] Unset Env"
-      run: |
-        echo "RUSTFLAGS=" >> $GITHUB_ENV
-        echo "LIBOMP_PATH=" >> $GITHUB_ENV
+    # - name: "[ckzg] Unset Env"
+    #   run: |
+    #     echo "RUSTFLAGS=" >> $GITHUB_ENV
+    #     echo "LIBOMP_PATH=" >> $GITHUB_ENV
 
 # 5th team ###########################################################
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,166 +19,166 @@ jobs:
         toolchain: stable
         components: clippy, rustfmt
 
-# # 1st team #########################################################
+# 1st team #########################################################
 
-#     - name: "[arkworks] Clippy"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: clippy
-#         args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
+    - name: "[arkworks] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
 
-#     - name: "[arkworks] Formatting"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: fmt
-#         args: --manifest-path Arkworks/Cargo.toml
+    - name: "[arkworks] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path Arkworks/Cargo.toml
         
-#     - name: "[arkworks] Tests without parallel"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: test
-#         args: --manifest-path Arkworks/Cargo.toml
+    - name: "[arkworks] Tests without parallel"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path Arkworks/Cargo.toml
 
-#     - name: "[arkworks] Tests with parallel"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: test
-#         args: --manifest-path Arkworks/Cargo.toml --features parallel
+    - name: "[arkworks] Tests with parallel"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path Arkworks/Cargo.toml --features parallel
 
-#     - name: "[arkworks] Benchmark without parallelization"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: bench
-#         args: --manifest-path Arkworks/Cargo.toml
+    - name: "[arkworks] Benchmark without parallelization"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path Arkworks/Cargo.toml
 
-#     - name: "[arkworks] Benchmark with parallelization"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: bench
-#         args: --manifest-path Arkworks/Cargo.toml --features parallel
+    - name: "[arkworks] Benchmark with parallelization"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path Arkworks/Cargo.toml --features parallel
 
-# # 2nd team #########################################################
+# 2nd team #########################################################
 
-#     - name: "[zkcrypto] Tests"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: test
-#         args: --manifest-path zkcrypto/Cargo.toml
+    - name: "[zkcrypto] Tests"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path zkcrypto/Cargo.toml
 
-#     - name: "[zkcrypto] Benches"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: bench
-#         args: --manifest-path zkcrypto/Cargo.toml
+    - name: "[zkcrypto] Benches"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path zkcrypto/Cargo.toml
 
-#     - name: "[zkcrypto] Clippy"
-#       uses: actions-rs/cargo@v1
-#       with:
-#        command: clippy
-#        args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
+    - name: "[zkcrypto] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+       command: clippy
+       args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
 
-#     - name: "[zkcrypto] Formatting"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: fmt
-#         args: --manifest-path zkcrypto/Cargo.toml
+    - name: "[zkcrypto] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path zkcrypto/Cargo.toml
 
-# # 3rd team #########################################################
+# 3rd team #########################################################
 
-#     - name: "[blst-from-scratch] Tests"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: test
-#         args: --manifest-path blst-from-scratch/Cargo.toml
+    - name: "[blst-from-scratch] Tests"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path blst-from-scratch/Cargo.toml
 
-#     - name: "[blst-from-scratch] Benchmark"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: bench
-#         args: --manifest-path blst-from-scratch/Cargo.toml
+    - name: "[blst-from-scratch] Benchmark"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path blst-from-scratch/Cargo.toml
 
-#     - name: "[blst-from-scratch] Clippy"
-#       uses: actions-rs/cargo@v1
-#       with:
-#        command: clippy
-#        args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
+    - name: "[blst-from-scratch] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+       command: clippy
+       args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
 
-#     - name: "[blst-from-scratch] Formatting"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: fmt
-#         args: --manifest-path blst-from-scratch/Cargo.toml
+    - name: "[blst-from-scratch] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path blst-from-scratch/Cargo.toml
 
-# # 4th team #########################################################
+# 4th team #########################################################
 
-#     - name: "[ckzg] Build native libs for Linux"
-#       if: matrix.os == 'ubuntu-latest'
-#       run: |
-#         echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
-#         echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
-#         cd ckzg && bash build.sh
+    - name: "[ckzg] Build native libs for Linux"
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
+        echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
+        cd ckzg && bash build.sh
 
-#     - name: "[ckzg] Build native libs for MacOS"
-#       if: matrix.os == 'macos-11'
-#       run: |
-#         brew install libomp gnu-sed
-#         echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
-#         echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
-#         cd ckzg && bash build.sh
+    - name: "[ckzg] Build native libs for MacOS"
+      if: matrix.os == 'macos-11'
+      run: |
+        brew install libomp gnu-sed
+        echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
+        echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+        cd ckzg && bash build.sh
 
-#     - name: "[ckzg] Setup Env"
-#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-#       run: |
-#         if [[ -z "$LIBOMP_PATH" ]]; then
-#           echo "FAIL: LLVM OpenMP runtime was not found"
-#           exit 1
-#         fi
-#         echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
+    - name: "[ckzg] Setup Env"
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      run: |
+        if [[ -z "$LIBOMP_PATH" ]]; then
+          echo "FAIL: LLVM OpenMP runtime was not found"
+          exit 1
+        fi
+        echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
 
-#     - name: "[ckzg] Tests without parallelization"
-#       uses: actions-rs/cargo@v1
-#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-#       with:
-#         command: test
-#         args: --manifest-path ckzg/Cargo.toml
+    - name: "[ckzg] Tests without parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: test
+        args: --manifest-path ckzg/Cargo.toml
 
-#     - name: "[ckzg] Tests with parallelization"
-#       uses: actions-rs/cargo@v1
-#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-#       with:
-#         command: test
-#         args: --manifest-path ckzg/Cargo.toml --features parallel
+    - name: "[ckzg] Tests with parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: test
+        args: --manifest-path ckzg/Cargo.toml --features parallel
 
-#     - name: "[ckzg] Benchmark without parallelization"
-#       uses: actions-rs/cargo@v1
-#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-#       with:
-#         command: bench
-#         args: --manifest-path ckzg/Cargo.toml
+    - name: "[ckzg] Benchmark without parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: bench
+        args: --manifest-path ckzg/Cargo.toml
 
-#     - name: "[ckzg] Benchmark with parallelization"
-#       uses: actions-rs/cargo@v1
-#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-#       with:
-#         command: bench
-#         args: --manifest-path ckzg/Cargo.toml --features parallel
+    - name: "[ckzg] Benchmark with parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: bench
+        args: --manifest-path ckzg/Cargo.toml --features parallel
 
-#     - name: "[ckzg] Clippy"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: clippy
-#         args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
+    - name: "[ckzg] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
 
-#     - name: "[ckzg] Formatting"
-#       uses: actions-rs/cargo@v1
-#       with:
-#         command: fmt
-#         args: --manifest-path ckzg/Cargo.toml
+    - name: "[ckzg] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path ckzg/Cargo.toml
 
-#     - name: "[ckzg] Unset Env"
-#       run: |
-#         echo "RUSTFLAGS=" >> $GITHUB_ENV
-#         echo "LIBOMP_PATH=" >> $GITHUB_ENV
+    - name: "[ckzg] Unset Env"
+      run: |
+        echo "RUSTFLAGS=" >> $GITHUB_ENV
+        echo "LIBOMP_PATH=" >> $GITHUB_ENV
 
 # 5th team ###########################################################
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,164 +21,164 @@ jobs:
 
 # 1st team #########################################################
 
-    # - name: "[arkworks] Clippy"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: clippy
-    #     args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
+    - name: "[arkworks] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
 
-    # - name: "[arkworks] Formatting"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: fmt
-    #     args: --manifest-path Arkworks/Cargo.toml
+    - name: "[arkworks] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path Arkworks/Cargo.toml
         
-    # - name: "[arkworks] Tests without parallel"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: test
-    #     args: --manifest-path Arkworks/Cargo.toml
+    - name: "[arkworks] Tests without parallel"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path Arkworks/Cargo.toml
 
-    # - name: "[arkworks] Tests with parallel"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: test
-    #     args: --manifest-path Arkworks/Cargo.toml --features parallel
+    - name: "[arkworks] Tests with parallel"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path Arkworks/Cargo.toml --features parallel
 
-    # - name: "[arkworks] Benchmark without parallelization"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: bench
-    #     args: --manifest-path Arkworks/Cargo.toml
+    - name: "[arkworks] Benchmark without parallelization"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path Arkworks/Cargo.toml
 
-    # - name: "[arkworks] Benchmark with parallelization"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: bench
-    #     args: --manifest-path Arkworks/Cargo.toml --features parallel
+    - name: "[arkworks] Benchmark with parallelization"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path Arkworks/Cargo.toml --features parallel
 
 # 2nd team #########################################################
 
-    # - name: "[zkcrypto] Tests"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: test
-    #     args: --manifest-path zkcrypto/Cargo.toml
+    - name: "[zkcrypto] Tests"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path zkcrypto/Cargo.toml
 
-    # - name: "[zkcrypto] Benches"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: bench
-    #     args: --manifest-path zkcrypto/Cargo.toml
+    - name: "[zkcrypto] Benches"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path zkcrypto/Cargo.toml
 
-    # - name: "[zkcrypto] Clippy"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #    command: clippy
-    #    args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
+    - name: "[zkcrypto] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+       command: clippy
+       args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
 
-    # - name: "[zkcrypto] Formatting"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: fmt
-    #     args: --manifest-path zkcrypto/Cargo.toml
+    - name: "[zkcrypto] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path zkcrypto/Cargo.toml
 
 # 3rd team #########################################################
 
-    # - name: "[blst-from-scratch] Tests"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: test
-    #     args: --manifest-path blst-from-scratch/Cargo.toml
+    - name: "[blst-from-scratch] Tests"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path blst-from-scratch/Cargo.toml
 
-    # - name: "[blst-from-scratch] Benchmark"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: bench
-    #     args: --manifest-path blst-from-scratch/Cargo.toml
+    - name: "[blst-from-scratch] Benchmark"
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --manifest-path blst-from-scratch/Cargo.toml
 
-    # - name: "[blst-from-scratch] Clippy"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #    command: clippy
-    #    args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
+    - name: "[blst-from-scratch] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+       command: clippy
+       args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
 
-    # - name: "[blst-from-scratch] Formatting"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: fmt
-    #     args: --manifest-path blst-from-scratch/Cargo.toml
+    - name: "[blst-from-scratch] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path blst-from-scratch/Cargo.toml
 
 # 4th team #########################################################
 
-    # - name: "[ckzg] Build native libs for Linux"
-    #   if: matrix.os == 'ubuntu-latest'
-    #   run: |
-    #     echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
-    #     echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
-    #     cd ckzg && bash build.sh
+    - name: "[ckzg] Build native libs for Linux"
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
+        echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
+        cd ckzg && bash build.sh
 
-    # - name: "[ckzg] Build native libs for MacOS"
-    #   if: matrix.os == 'macos-11'
-    #   run: |
-    #     brew install libomp gnu-sed
-    #     echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
-    #     echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
-    #     cd ckzg && bash build.sh
+    - name: "[ckzg] Build native libs for MacOS"
+      if: matrix.os == 'macos-11'
+      run: |
+        brew install libomp gnu-sed
+        echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
+        echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+        cd ckzg && bash build.sh
 
-    # - name: "[ckzg] Setup Env"
-    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-    #   run: |
-    #     if [[ -z "$LIBOMP_PATH" ]]; then
-    #       echo "FAIL: LLVM OpenMP runtime was not found"
-    #       exit 1
-    #     fi
-    #     echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
+    - name: "[ckzg] Setup Env"
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      run: |
+        if [[ -z "$LIBOMP_PATH" ]]; then
+          echo "FAIL: LLVM OpenMP runtime was not found"
+          exit 1
+        fi
+        echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
 
-    # - name: "[ckzg] Tests without parallelization"
-    #   uses: actions-rs/cargo@v1
-    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-    #   with:
-    #     command: test
-    #     args: --manifest-path ckzg/Cargo.toml
+    - name: "[ckzg] Tests without parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: test
+        args: --manifest-path ckzg/Cargo.toml
 
-    # - name: "[ckzg] Tests with parallelization"
-    #   uses: actions-rs/cargo@v1
-    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-    #   with:
-    #     command: test
-    #     args: --manifest-path ckzg/Cargo.toml --features parallel
+    - name: "[ckzg] Tests with parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: test
+        args: --manifest-path ckzg/Cargo.toml --features parallel
 
-    # - name: "[ckzg] Benchmark without parallelization"
-    #   uses: actions-rs/cargo@v1
-    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-    #   with:
-    #     command: bench
-    #     args: --manifest-path ckzg/Cargo.toml
+    - name: "[ckzg] Benchmark without parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: bench
+        args: --manifest-path ckzg/Cargo.toml
 
-    # - name: "[ckzg] Benchmark with parallelization"
-    #   uses: actions-rs/cargo@v1
-    #   if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-    #   with:
-    #     command: bench
-    #     args: --manifest-path ckzg/Cargo.toml --features parallel
+    - name: "[ckzg] Benchmark with parallelization"
+      uses: actions-rs/cargo@v1
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+      with:
+        command: bench
+        args: --manifest-path ckzg/Cargo.toml --features parallel
 
-    # - name: "[ckzg] Clippy"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: clippy
-    #     args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
+    - name: "[ckzg] Clippy"
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
 
-    # - name: "[ckzg] Formatting"
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: fmt
-    #     args: --manifest-path ckzg/Cargo.toml
+    - name: "[ckzg] Formatting"
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --manifest-path ckzg/Cargo.toml
 
-    # - name: "[ckzg] Unset Env"
-    #   run: |
-    #     echo "RUSTFLAGS=" >> $GITHUB_ENV
-    #     echo "LIBOMP_PATH=" >> $GITHUB_ENV
+    - name: "[ckzg] Unset Env"
+      run: |
+        echo "RUSTFLAGS=" >> $GITHUB_ENV
+        echo "LIBOMP_PATH=" >> $GITHUB_ENV
 
 # 5th team ###########################################################
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,166 +19,166 @@ jobs:
         toolchain: stable
         components: clippy, rustfmt
 
-# 1st team #########################################################
+# # 1st team #########################################################
 
-    - name: "[arkworks] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
+#     - name: "[arkworks] Clippy"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: clippy
+#         args: --manifest-path Arkworks/Cargo.toml --all-targets --all-features -- -D warnings
 
-    - name: "[arkworks] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path Arkworks/Cargo.toml
+#     - name: "[arkworks] Formatting"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: fmt
+#         args: --manifest-path Arkworks/Cargo.toml
         
-    - name: "[arkworks] Tests without parallel"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path Arkworks/Cargo.toml
+#     - name: "[arkworks] Tests without parallel"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: test
+#         args: --manifest-path Arkworks/Cargo.toml
 
-    - name: "[arkworks] Tests with parallel"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path Arkworks/Cargo.toml --features parallel
+#     - name: "[arkworks] Tests with parallel"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: test
+#         args: --manifest-path Arkworks/Cargo.toml --features parallel
 
-    - name: "[arkworks] Benchmark without parallelization"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path Arkworks/Cargo.toml
+#     - name: "[arkworks] Benchmark without parallelization"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: bench
+#         args: --manifest-path Arkworks/Cargo.toml
 
-    - name: "[arkworks] Benchmark with parallelization"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path Arkworks/Cargo.toml --features parallel
+#     - name: "[arkworks] Benchmark with parallelization"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: bench
+#         args: --manifest-path Arkworks/Cargo.toml --features parallel
 
-# 2nd team #########################################################
+# # 2nd team #########################################################
 
-    - name: "[zkcrypto] Tests"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path zkcrypto/Cargo.toml
+#     - name: "[zkcrypto] Tests"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: test
+#         args: --manifest-path zkcrypto/Cargo.toml
 
-    - name: "[zkcrypto] Benches"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path zkcrypto/Cargo.toml
+#     - name: "[zkcrypto] Benches"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: bench
+#         args: --manifest-path zkcrypto/Cargo.toml
 
-    - name: "[zkcrypto] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-       command: clippy
-       args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
+#     - name: "[zkcrypto] Clippy"
+#       uses: actions-rs/cargo@v1
+#       with:
+#        command: clippy
+#        args: --manifest-path zkcrypto/Cargo.toml --all-targets --all-features -- -D warnings
 
-    - name: "[zkcrypto] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path zkcrypto/Cargo.toml
+#     - name: "[zkcrypto] Formatting"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: fmt
+#         args: --manifest-path zkcrypto/Cargo.toml
 
-# 3rd team #########################################################
+# # 3rd team #########################################################
 
-    - name: "[blst-from-scratch] Tests"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path blst-from-scratch/Cargo.toml
+#     - name: "[blst-from-scratch] Tests"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: test
+#         args: --manifest-path blst-from-scratch/Cargo.toml
 
-    - name: "[blst-from-scratch] Benchmark"
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --manifest-path blst-from-scratch/Cargo.toml
+#     - name: "[blst-from-scratch] Benchmark"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: bench
+#         args: --manifest-path blst-from-scratch/Cargo.toml
 
-    - name: "[blst-from-scratch] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-       command: clippy
-       args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
+#     - name: "[blst-from-scratch] Clippy"
+#       uses: actions-rs/cargo@v1
+#       with:
+#        command: clippy
+#        args: --manifest-path blst-from-scratch/Cargo.toml --all-targets --all-features --
 
-    - name: "[blst-from-scratch] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path blst-from-scratch/Cargo.toml
+#     - name: "[blst-from-scratch] Formatting"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: fmt
+#         args: --manifest-path blst-from-scratch/Cargo.toml
 
-# 4th team #########################################################
+# # 4th team #########################################################
 
-    - name: "[ckzg] Build native libs for Linux"
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
-        echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
-        cd ckzg && bash build.sh
+#     - name: "[ckzg] Build native libs for Linux"
+#       if: matrix.os == 'ubuntu-latest'
+#       run: |
+#         echo "LIBOMP_PATH=$(find /usr/lib/llvm* -name libiomp5.so | head -n 1)" >> $GITHUB_ENV
+#         echo "OMP_NUM_THREADS=$(nproc)" >> $GITHUB_ENV
+#         cd ckzg && bash build.sh
 
-    - name: "[ckzg] Build native libs for MacOS"
-      if: matrix.os == 'macos-11'
-      run: |
-        brew install libomp gnu-sed
-        echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
-        echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
-        cd ckzg && bash build.sh
+#     - name: "[ckzg] Build native libs for MacOS"
+#       if: matrix.os == 'macos-11'
+#       run: |
+#         brew install libomp gnu-sed
+#         echo "LIBOMP_PATH=/usr/local/lib/libomp.dylib" >> $GITHUB_ENV
+#         echo "OMP_NUM_THREADS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+#         cd ckzg && bash build.sh
 
-    - name: "[ckzg] Setup Env"
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      run: |
-        if [[ -z "$LIBOMP_PATH" ]]; then
-          echo "FAIL: LLVM OpenMP runtime was not found"
-          exit 1
-        fi
-        echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
+#     - name: "[ckzg] Setup Env"
+#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+#       run: |
+#         if [[ -z "$LIBOMP_PATH" ]]; then
+#           echo "FAIL: LLVM OpenMP runtime was not found"
+#           exit 1
+#         fi
+#         echo "RUSTFLAGS=-C link-arg="$LIBOMP_PATH"" >> $GITHUB_ENV
 
-    - name: "[ckzg] Tests without parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: test
-        args: --manifest-path ckzg/Cargo.toml
+#     - name: "[ckzg] Tests without parallelization"
+#       uses: actions-rs/cargo@v1
+#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+#       with:
+#         command: test
+#         args: --manifest-path ckzg/Cargo.toml
 
-    - name: "[ckzg] Tests with parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: test
-        args: --manifest-path ckzg/Cargo.toml --features parallel
+#     - name: "[ckzg] Tests with parallelization"
+#       uses: actions-rs/cargo@v1
+#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+#       with:
+#         command: test
+#         args: --manifest-path ckzg/Cargo.toml --features parallel
 
-    - name: "[ckzg] Benchmark without parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: bench
-        args: --manifest-path ckzg/Cargo.toml
+#     - name: "[ckzg] Benchmark without parallelization"
+#       uses: actions-rs/cargo@v1
+#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+#       with:
+#         command: bench
+#         args: --manifest-path ckzg/Cargo.toml
 
-    - name: "[ckzg] Benchmark with parallelization"
-      uses: actions-rs/cargo@v1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
-      with:
-        command: bench
-        args: --manifest-path ckzg/Cargo.toml --features parallel
+#     - name: "[ckzg] Benchmark with parallelization"
+#       uses: actions-rs/cargo@v1
+#       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
+#       with:
+#         command: bench
+#         args: --manifest-path ckzg/Cargo.toml --features parallel
 
-    - name: "[ckzg] Clippy"
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
+#     - name: "[ckzg] Clippy"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: clippy
+#         args: --manifest-path ckzg/Cargo.toml --all-targets --all-features -- -D warnings
 
-    - name: "[ckzg] Formatting"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path ckzg/Cargo.toml
+#     - name: "[ckzg] Formatting"
+#       uses: actions-rs/cargo@v1
+#       with:
+#         command: fmt
+#         args: --manifest-path ckzg/Cargo.toml
 
-    - name: "[ckzg] Unset Env"
-      run: |
-        echo "RUSTFLAGS=" >> $GITHUB_ENV
-        echo "LIBOMP_PATH=" >> $GITHUB_ENV
+#     - name: "[ckzg] Unset Env"
+#       run: |
+#         echo "RUSTFLAGS=" >> $GITHUB_ENV
+#         echo "LIBOMP_PATH=" >> $GITHUB_ENV
 
 # 5th team ###########################################################
 

--- a/mcl-kzg/kzg-bench/src/test.rs
+++ b/mcl-kzg/kzg-bench/src/test.rs
@@ -43,7 +43,7 @@ fn mcl_test() {
 
     let x = Fr::from_int(3);
     let y = Fp::from_int(-1);
-    let mut e = unsafe { GT::uninit() };
+    let mut e = GT::zero();
     pairing(&mut e, &p, &q);
     serialize_test! {Fr, x};
     serialize_test! {Fp, y};

--- a/mcl-kzg/kzg-bench/src/test_macro.rs
+++ b/mcl-kzg/kzg-bench/src/test_macro.rs
@@ -24,8 +24,8 @@ macro_rules! field_test {
         x.set_int(-124);
         assert!(x.is_negative());
 
-        let mut z = unsafe { <$t>::uninit() };
-        let mut w = unsafe { <$t>::uninit() };
+        let mut z = <$t>::zero();
+        let mut w = <$t>::zero();
 
         let a = 256;
         let b = 8;
@@ -85,13 +85,13 @@ macro_rules! ec_test {
         assert!(p1.is_zero());
         assert_ne!(p1, $p);
         <$t>::neg(&mut p1, &$p);
-        let mut x: $f = unsafe { <$f>::uninit() };
+        let mut x: $f = <$f>::zero();
         <$f>::neg(&mut x, &p1.y);
         assert_eq!(&x, &$p.y);
 
         <$t>::dbl(&mut p1, &$p);
-        let mut p2: $t = unsafe { <$t>::uninit() };
-        let mut p3: $t = unsafe { <$t>::uninit() };
+        let mut p2: $t = <$t>::zero();
+        let mut p3: $t = <$t>::zero();
         <$t>::add(&mut p2, &$p, &$p);
         assert_eq!(p2, p1);
         <$t>::add(&mut p3, &p2, &$p);
@@ -118,7 +118,7 @@ macro_rules! ec_test {
 macro_rules! serialize_test {
     ($t:ty, $x:expr) => {
         let buf = $x.serialize();
-        let mut y: $t = unsafe { <$t>::uninit() };
+        let mut y: $t = <$t>::zero();
         assert!(y.deserialize(&buf));
         assert_eq!($x, y);
     };

--- a/mcl-kzg/kzg/Cargo.toml
+++ b/mcl-kzg/kzg/Cargo.toml
@@ -14,6 +14,7 @@ blst = {'git' = 'https://github.com/supranational/blst.git'}
 kzg = { path = "../../kzg" }
 primitive-types = "0.10.1"
 rayon = { version = "1.5.1", optional = true }
+once_cell = "1.4.0"
 
 [features]
 parallel = ["rayon"]

--- a/mcl-kzg/kzg/src/data_recovery.rs
+++ b/mcl-kzg/kzg/src/data_recovery.rs
@@ -41,6 +41,7 @@ impl Polynomial {
         }
     }
 
+    #[allow(clippy::needless_range_loop)]
     pub fn unshift_in_place(&mut self) {
         let scale_factor = Fr::from_int(PRIMITIVE_ROOT);
         #[cfg(feature = "parallel")]

--- a/mcl-kzg/kzg/src/data_recovery.rs
+++ b/mcl-kzg/kzg/src/data_recovery.rs
@@ -4,42 +4,36 @@ use crate::data_types::fr::Fr;
 use crate::utilities::is_power_of_2;
 #[cfg(feature = "parallel")]
 use crate::utilities::next_pow_of_2;
+#[cfg(feature = "parallel")]
+use once_cell::sync::OnceCell;
 
 #[cfg(feature = "parallel")]
-static mut INVERSE_FACTORS: Vec<Fr> = Vec::new();
+static INVERSE_FACTORS: OnceCell<Vec<Fr>> = OnceCell::new();
 #[cfg(feature = "parallel")]
-static mut UNSHIFT_FACTOR_POWERS: Vec<Fr> = Vec::new();
+static UNSHIFT_FACTOR_POWERS: OnceCell<Vec<Fr>> = OnceCell::new();
 
 impl Polynomial {
+
+    #[allow(clippy::needless_range_loop)]
     pub fn shift_in_place(&mut self) {
         let inv_factor = Fr::from_int(PRIMITIVE_ROOT).get_inv();
         #[cfg(feature = "parallel")]
         {
-            let optim = next_pow_of_2(self.order() - 1);
-            if optim <= 1024
-            {
-                unsafe {
-                    if INVERSE_FACTORS.len() < self.order() {
-                        if INVERSE_FACTORS.is_empty() {
-                            INVERSE_FACTORS.push(Fr::one());
-                        }
-                        for i in (INVERSE_FACTORS.len())..self.order() {
-                            let mut res = Fr::zero();
-                            Fr::mul(&mut res, &INVERSE_FACTORS[i-1], &inv_factor);
-                            INVERSE_FACTORS.push(res);
-                        }
-                    }
+            let factors = INVERSE_FACTORS.get_or_init( || {
+                let mut temp: Vec<Fr> = vec![Fr::one()];
+                for i in 1..65536 {
+                    let mut res = Fr::zero();
+                    Fr::mul(&mut res, &temp[i - 1], &inv_factor);
 
-                    for (i, factor) in INVERSE_FACTORS.iter().enumerate().take(self.order()).skip(1) {
-                        self.coeffs[i] *= factor;
-                    }
+                    temp.push(res);
                 }
-            }
-            else
-            {
-                self._shift_in_place(&inv_factor);
-            }
 
+                temp
+            });
+
+            for i in 1..self.order() {
+                self.coeffs[i] *= &factors[i];
+            }
         }
         #[cfg(not(feature="parallel"))]
         {
@@ -51,21 +45,20 @@ impl Polynomial {
         let scale_factor = Fr::from_int(PRIMITIVE_ROOT);
         #[cfg(feature = "parallel")]
         {
-            unsafe {
-                if UNSHIFT_FACTOR_POWERS.len() < self.order() {
-                    if UNSHIFT_FACTOR_POWERS.is_empty() {
-                        UNSHIFT_FACTOR_POWERS.push(Fr::one());
-                    }
-                    for i in (UNSHIFT_FACTOR_POWERS.len())..self.order() {
-                        let mut res = Fr::zero();
-                        Fr::mul(&mut res, &UNSHIFT_FACTOR_POWERS[i-1], &scale_factor);
-                        UNSHIFT_FACTOR_POWERS.push(res);
-                    }
+            let factors = UNSHIFT_FACTOR_POWERS.get_or_init( || {
+                let mut temp: Vec<Fr> = vec![Fr::one()];
+                for i in 1..65536 {
+                    let mut res = Fr::zero();
+                    Fr::mul(&mut res, &temp[i - 1], &scale_factor);
+
+                    temp.push(res);
                 }
-    
-                for (i, factor) in UNSHIFT_FACTOR_POWERS.iter().enumerate().take(self.order()).skip(1) {
-                    self.coeffs[i] *= factor;
-                }
+
+                temp
+            });
+
+            for i in 1..self.order() {
+                self.coeffs[i] *= &factors[i];
             }
         }
         #[cfg(not(feature="parallel"))]

--- a/mcl-kzg/kzg/src/data_types/fp.rs
+++ b/mcl-kzg/kzg/src/data_types/fp.rs
@@ -2,7 +2,6 @@ use std::ops::{Add, AddAssign};
 use std::ops::{Div, DivAssign};
 use std::ops::{Mul, MulAssign};
 use std::ops::{Sub, SubAssign};
-use std::mem::MaybeUninit;
 use std::os::raw::c_int;
 use crate::mcl_methods::*;
 

--- a/mcl-kzg/kzg/src/data_types/fp2.rs
+++ b/mcl-kzg/kzg/src/data_types/fp2.rs
@@ -4,7 +4,6 @@ use std::ops::{Add, AddAssign};
 use std::ops::{Div, DivAssign};
 use std::ops::{Mul, MulAssign};
 use std::ops::{Sub, SubAssign};
-use std::mem::MaybeUninit;
 use std::os::raw::c_int;
 use crate::mcl_methods;
 

--- a/mcl-kzg/kzg/src/data_types/fr.rs
+++ b/mcl-kzg/kzg/src/data_types/fr.rs
@@ -1,6 +1,5 @@
 use crate::mcl_methods;
 use primitive_types::U256;
-use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign};
 use std::ops::{Div, DivAssign};
 use std::ops::{Mul, MulAssign};

--- a/mcl-kzg/kzg/src/data_types/g1.rs
+++ b/mcl-kzg/kzg/src/data_types/g1.rs
@@ -2,7 +2,6 @@ use crate::data_types::fp::Fp;
 use crate::data_types::fr::Fr;
 use crate::mcl_methods;
 use crate::utilities::arr64_6_to_g1_sum;
-use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign};
 use std::ops::{Sub, SubAssign};
 use std::os::raw::c_int;

--- a/mcl-kzg/kzg/src/data_types/g2.rs
+++ b/mcl-kzg/kzg/src/data_types/g2.rs
@@ -3,7 +3,6 @@ use crate::data_types::fp::Fp;
 use crate::data_types::fp2::Fp2;
 use std::ops::{Add, AddAssign};
 use std::ops::{Sub, SubAssign};
-use std::mem::MaybeUninit;
 use std::os::raw::c_int;
 use crate::mcl_methods;
 

--- a/mcl-kzg/kzg/src/data_types/gt.rs
+++ b/mcl-kzg/kzg/src/data_types/gt.rs
@@ -4,7 +4,6 @@ use std::ops::{Add, AddAssign};
 use std::ops::{Div, DivAssign};
 use std::ops::{Mul, MulAssign};
 use std::ops::{Sub, SubAssign};
-use std::mem::MaybeUninit;
 use std::os::raw::c_int;
 use crate::mcl_methods;
 

--- a/mcl-kzg/kzg/src/init_def.rs
+++ b/mcl-kzg/kzg/src/init_def.rs
@@ -9,12 +9,6 @@ macro_rules! common_impl {
             pub fn zero() -> $t {
                 Default::default()
             }
-            /// # Safety
-            ///
-            /// MCL Function, unsure why it is unsafe
-            pub unsafe fn uninit() -> $t {
-                std::mem::MaybeUninit::uninit().assume_init()
-            }
             pub fn clear(&mut self) {
                 *self = <$t>::zero()
             }
@@ -72,7 +66,7 @@ macro_rules! str_impl {
     ($t:ty, $maxBufSize:expr, $get_str_fn:ident, $set_str_fn:ident) => {
         impl $t {
             pub fn from_str(s: &str, base: i32) -> Option<$t> {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 if v.set_str(s, base) {
                     return Some(v);
                 }
@@ -82,7 +76,7 @@ macro_rules! str_impl {
                 unsafe { $set_str_fn(self, s.as_ptr(), s.len(), base) == 0 }
             }
             pub fn get_str(&self, io_mode: i32) -> String {
-                let mut buf: [u8; $maxBufSize] = unsafe { MaybeUninit::uninit().assume_init() };
+                let mut buf: [u8; $maxBufSize] = [0; $maxBufSize];
                 let n: usize;
                 unsafe {
                     n = $get_str_fn(buf.as_mut_ptr(), buf.len(), self, io_mode);
@@ -100,7 +94,7 @@ macro_rules! int_impl {
     ($t:ty, $set_int_fn:ident, $is_one_fn:ident) => {
         impl $t {
             pub fn from_int(x: i32) -> $t {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 v.set_int(x);
                 v
             }
@@ -160,7 +154,7 @@ macro_rules! add_op_impl {
         impl<'a> Add for &'a $t {
             type Output = $t;
             fn add(self, other: &$t) -> $t {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::add(&mut v, &self, &other);
                 v
             }
@@ -169,7 +163,7 @@ macro_rules! add_op_impl {
             fn add_assign(&mut self, other: &$t) {
                 // how can I write this?
                 // unsafe { <$t>::add(&mut self, &self, &other); }
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::add(&mut v, &self, &other);
                 *self = v;
             }
@@ -177,14 +171,14 @@ macro_rules! add_op_impl {
         impl<'a> Sub for &'a $t {
             type Output = $t;
             fn sub(self, other: &$t) -> $t {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::sub(&mut v, &self, &other);
                 v
             }
         }
         impl<'a> SubAssign<&'a $t> for $t {
             fn sub_assign(&mut self, other: &$t) {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::sub(&mut v, &self, &other);
                 *self = v;
             }
@@ -211,14 +205,14 @@ macro_rules! field_mul_op_impl {
         impl<'a> Mul for &'a $t {
             type Output = $t;
             fn mul(self, other: &$t) -> $t {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::mul(&mut v, &self, &other);
                 v
             }
         }
         impl<'a> MulAssign<&'a $t> for $t {
             fn mul_assign(&mut self, other: &$t) {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::mul(&mut v, &self, &other);
                 *self = v;
             }
@@ -226,14 +220,14 @@ macro_rules! field_mul_op_impl {
         impl<'a> Div for &'a $t {
             type Output = $t;
             fn div(self, other: &$t) -> $t {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::div(&mut v, &self, &other);
                 v
             }
         }
         impl<'a> DivAssign<&'a $t> for $t {
             fn div_assign(&mut self, other: &$t) {
-                let mut v = unsafe { <$t>::uninit() };
+                let mut v = <$t>::zero();
                 <$t>::div(&mut v, &self, &other);
                 *self = v;
             }
@@ -263,7 +257,7 @@ macro_rules! ec_impl {
 
 macro_rules! get_str_impl {
     ($get_str_fn:ident) => {{
-        let mut buf: [u8; 256] = unsafe { MaybeUninit::uninit().assume_init() };
+        let mut buf: [u8; 256] = [0; 256];
         let n: usize;
         unsafe {
             n = $get_str_fn(buf.as_mut_ptr(), buf.len());

--- a/mcl-kzg/kzg/src/mcl_methods.rs
+++ b/mcl-kzg/kzg/src/mcl_methods.rs
@@ -2,7 +2,6 @@ use crate::data_types::fr::Fr;
 use crate::data_types::g1::G1;
 use crate::data_types::g2::G2;
 use crate::data_types::gt::GT;
-use std::mem::MaybeUninit;
 use crate::CurveType;
 use std::os::raw::c_int;
 


### PR DESCRIPTION
This branch is just a reset of original `mcl/style-fixes` branch, back to the changes before "new" `MaybeUninit` implementation.
It contains:
- MaybeUninit changed to simply `type::zero()`,
- Using `OnceCell` instead of `static mut` variables in Recovery.