### PR TITLE
Add more tests and benchmarks for the new interface

### DIFF
--- a/blst-from-scratch/benches/eip_4844.rs
+++ b/blst-from-scratch/benches/eip_4844.rs
@@ -1,31 +1,59 @@
-use blst_from_scratch::{types::{fr::FsFr, g1::FsG1, g2::FsG2, poly::FsPoly, fft_settings::FsFFTSettings, kzg_settings::FsKZGSettings}, eip_4844::{load_trusted_setup, blob_to_kzg_commitment, compute_aggregate_kzg_proof, verify_aggregate_kzg_proof}};
-use criterion::{Criterion, criterion_group, criterion_main};
-use kzg_bench::benches::eip_4844::{bench_compute_aggregate_kzg_proof, bench_verify_aggregate_kzg_proof};
+use blst_from_scratch::{
+    eip_4844::{
+        blob_to_kzg_commitment, compute_aggregate_kzg_proof, load_trusted_setup,
+        verify_aggregate_kzg_proof,
+    },
+    types::{
+        fft_settings::FsFFTSettings, fr::FsFr, g1::FsG1, g2::FsG2, kzg_settings::FsKZGSettings,
+        poly::FsPoly,
+    },
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg_bench::benches::eip_4844::{
+    bench_compute_aggregate_kzg_proof, bench_verify_aggregate_kzg_proof,
+};
 
-fn bench_compute_aggregate_kzg_proof_(c: &mut Criterion) {
-    bench_compute_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>
-    (
+fn bench_compute_aggregate_kzg_proof_3(c: &mut Criterion) {
+    bench_compute_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
         c,
         &load_trusted_setup,
         &compute_aggregate_kzg_proof,
-    ) 
+        3,
+    )
+}
+
+fn bench_compute_aggregate_kzg_proof_8(c: &mut Criterion) {
+    bench_compute_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+        c,
+        &load_trusted_setup,
+        &compute_aggregate_kzg_proof,
+        8,
+    )
+}
+
+fn bench_compute_aggregate_kzg_proof_16(c: &mut Criterion) {
+    bench_compute_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+        c,
+        &load_trusted_setup,
+        &compute_aggregate_kzg_proof,
+        16,
+    )
 }
 
 fn bench_verify_aggregate_kzg_proof_(c: &mut Criterion) {
-    bench_verify_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>
-    (
+    bench_verify_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
         c,
         &load_trusted_setup,
         &blob_to_kzg_commitment,
         &compute_aggregate_kzg_proof,
         &verify_aggregate_kzg_proof,
-    ) 
+    )
 }
 
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_compute_aggregate_kzg_proof_, bench_verify_aggregate_kzg_proof_
+    targets = bench_compute_aggregate_kzg_proof_3, bench_compute_aggregate_kzg_proof_8, bench_compute_aggregate_kzg_proof_16, bench_verify_aggregate_kzg_proof_
 }
 
 criterion_main!(benches);

--- a/blst-from-scratch/benches/eip_4844.rs
+++ b/blst-from-scratch/benches/eip_4844.rs
@@ -13,16 +13,16 @@ use kzg_bench::benches::eip_4844::{
     bench_compute_aggregate_kzg_proof, bench_verify_aggregate_kzg_proof,
 };
 
-fn bench_compute_aggregate_kzg_proof_3(c: &mut Criterion) {
+fn bench_compute_aggregate_kzg_proof_4_(c: &mut Criterion) {
     bench_compute_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
         c,
         &load_trusted_setup,
         &compute_aggregate_kzg_proof,
-        3,
+        4,
     )
 }
 
-fn bench_compute_aggregate_kzg_proof_8(c: &mut Criterion) {
+fn bench_compute_aggregate_kzg_proof_8_(c: &mut Criterion) {
     bench_compute_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
         c,
         &load_trusted_setup,
@@ -31,7 +31,7 @@ fn bench_compute_aggregate_kzg_proof_8(c: &mut Criterion) {
     )
 }
 
-fn bench_compute_aggregate_kzg_proof_16(c: &mut Criterion) {
+fn bench_compute_aggregate_kzg_proof_16_(c: &mut Criterion) {
     bench_compute_aggregate_kzg_proof::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
         c,
         &load_trusted_setup,
@@ -53,7 +53,7 @@ fn bench_verify_aggregate_kzg_proof_(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_compute_aggregate_kzg_proof_3, bench_compute_aggregate_kzg_proof_8, bench_compute_aggregate_kzg_proof_16, bench_verify_aggregate_kzg_proof_
+    targets = bench_compute_aggregate_kzg_proof_4_, bench_compute_aggregate_kzg_proof_8_, bench_compute_aggregate_kzg_proof_16_, bench_verify_aggregate_kzg_proof_
 }
 
 criterion_main!(benches);

--- a/blst-from-scratch/tests/eip_4844.rs
+++ b/blst-from-scratch/tests/eip_4844.rs
@@ -4,8 +4,9 @@ mod tests {
     use blst_from_scratch::{
         eip_4844::{
             blob_to_kzg_commitment, bytes_from_bls_field, bytes_from_g1, bytes_to_bls_field,
-            compute_kzg_proof, compute_powers, evaluate_polynomial_in_evaluation_form, g1_lincomb,
-            load_trusted_setup, vector_lincomb, verify_kzg_proof, compute_aggregate_kzg_proof, verify_aggregate_kzg_proof,
+            compute_aggregate_kzg_proof, compute_kzg_proof, compute_powers,
+            evaluate_polynomial_in_evaluation_form, g1_lincomb, load_trusted_setup, vector_lincomb,
+            verify_aggregate_kzg_proof, verify_kzg_proof,
         },
         types::{
             fft_settings::FsFFTSettings, fr::FsFr, g1::FsG1, g2::FsG2, kzg_settings::FsKZGSettings,
@@ -13,8 +14,8 @@ mod tests {
         },
     };
     use kzg_bench::tests::eip_4844::{
-        bytes_to_bls_field_test, compute_commitment_for_blobs_test, compute_powers_test,
-        evaluate_polynomial_in_evaluation_form_test, eip4844_test,
+        blob_to_kzg_commitment_test, bytes_to_bls_field_test, compute_commitment_for_blobs_test,
+        compute_powers_test, eip4844_test, evaluate_polynomial_in_evaluation_form_test,
     };
 
     #[test]
@@ -66,7 +67,16 @@ mod tests {
             &load_trusted_setup,
             &blob_to_kzg_commitment,
             &compute_aggregate_kzg_proof,
-            &verify_aggregate_kzg_proof
+            &verify_aggregate_kzg_proof,
         );
+    }
+
+    #[test]
+    pub fn blob_to_kzg_commitment_test_() {
+        blob_to_kzg_commitment_test::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+            &load_trusted_setup,
+            &blob_to_kzg_commitment,
+            &bytes_from_g1,
+        )
     }
 }

--- a/blst-from-scratch/tests/eip_4844.rs
+++ b/blst-from-scratch/tests/eip_4844.rs
@@ -15,7 +15,7 @@ mod tests {
     };
     use kzg_bench::tests::eip_4844::{
         blob_to_kzg_commitment_test, bytes_to_bls_field_test, compute_commitment_for_blobs_test,
-        compute_powers_test, eip4844_test, evaluate_polynomial_in_evaluation_form_test,
+        compute_powers_test, eip4844_test, evaluate_polynomial_in_evaluation_form_test, compute_aggregate_kzg_proof_test_empty, aggregate_proof_for_single_blob_test,
     };
 
     #[test]
@@ -78,5 +78,33 @@ mod tests {
             &blob_to_kzg_commitment,
             &bytes_from_g1,
         )
+    }
+
+    #[test]
+    pub fn compute_aggregate_kzg_proof_test_empty_() {
+        compute_aggregate_kzg_proof_test_empty::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+            &load_trusted_setup,
+            &compute_aggregate_kzg_proof,
+            &bytes_from_g1,
+        )
+    }
+
+    // #[test]
+    // pub fn verify_aggregate_kzg_proof_test_empty_() {
+    //     verify_aggregate_kzg_proof_test_empty::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+    //         &load_trusted_setup,
+    //         &compute_aggregate_kzg_proof,
+    //         &verify_aggregate_kzg_proof,
+    //     )
+    // }
+
+    #[test]
+    pub fn aggregate_proof_for_single_blob_test_() {
+        aggregate_proof_for_single_blob_test::<FsFr, FsG1, FsG2, FsPoly, FsFFTSettings, FsKZGSettings>(
+            &load_trusted_setup,
+            &blob_to_kzg_commitment,
+            &compute_aggregate_kzg_proof,
+            &verify_aggregate_kzg_proof,
+        );
     }
 }

--- a/kzg-bench/src/benches/eip_4844.rs
+++ b/kzg-bench/src/benches/eip_4844.rs
@@ -16,13 +16,14 @@ pub fn bench_compute_aggregate_kzg_proof<
 >(
     c: &mut Criterion,
     load_trusted_setup: &dyn Fn(&str) -> TKZGSettings,
-    compute_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &TKZGSettings) -> TG1
+    compute_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &TKZGSettings) -> TG1,
+    blob_count: usize,
 ) {
     const BLOB_SIZE: usize = 4096;
 
     let mut rng = StdRng::seed_from_u64(0);
 
-    let blobs = (0..3)
+    let blobs = (0..blob_count)
         .map(|_| {
             (0..BLOB_SIZE)
                 .map(|_| TFr::from_u64_arr(&rng.gen()))

--- a/kzg-bench/src/benches/eip_4844.rs
+++ b/kzg-bench/src/benches/eip_4844.rs
@@ -34,7 +34,7 @@ pub fn bench_compute_aggregate_kzg_proof<
     set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
     let ts = load_trusted_setup("src/trusted_setups/trusted_setup.txt");
 
-    let id = format!("bench_compute_aggregate_kzg_proof scale: '{}'", BENCH_SCALE);
+    let id = format!("bench_compute_aggregate_kzg_proof_{} scale: '{}'", blob_count, BENCH_SCALE);
     c.bench_function(&id, move |b| b.iter(|| compute_aggregate_kzg_proof(&blobs, &ts)));
 }
 

--- a/kzg-bench/src/tests/eip_4844.rs
+++ b/kzg-bench/src/tests/eip_4844.rs
@@ -365,24 +365,25 @@ pub fn compute_aggregate_kzg_proof_test_empty<
     assert_eq!(bytes_from_g1(&empty_proof), expected_proof);
 }
 
-pub fn verify_aggregate_kzg_proof_test_empty<
-    TFr : Fr,
-    TG1: G1,
-    TG2: G2,
-    TPoly: Poly<TFr>,
-    TFFTSettings: FFTSettings<TFr>,
-    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly>
->(
-    load_trusted_setup: &dyn Fn(&str) -> TKZGSettings, 
-    compute_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &TKZGSettings) -> TG1,
-    verify_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &[TG1], &TG1, &TKZGSettings) -> bool,
-) {
+// unclear what the verify value should be with an empty blob
+// pub fn verify_aggregate_kzg_proof_test_empty<
+//     TFr : Fr,
+//     TG1: G1,
+//     TG2: G2,
+//     TPoly: Poly<TFr>,
+//     TFFTSettings: FFTSettings<TFr>,
+//     TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly>
+// >(
+//     load_trusted_setup: &dyn Fn(&str) -> TKZGSettings, 
+//     compute_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &TKZGSettings) -> TG1,
+//     verify_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &[TG1], &TG1, &TKZGSettings) -> bool,
+// ) {
 
-    set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
-    let ts = load_trusted_setup("src/trusted_setups/trusted_setup.txt");
+//     set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
+//     let ts = load_trusted_setup("src/trusted_setups/trusted_setup.txt");
 
-    assert!(verify_aggregate_kzg_proof(&[], &[], &compute_aggregate_kzg_proof(&[], &ts), &ts), "verify failed");
-}
+//     assert!(verify_aggregate_kzg_proof(&[], &[], &compute_aggregate_kzg_proof(&[], &ts), &ts), "verify failed");
+// }
 
 pub fn aggregate_proof_for_single_blob_test<
     TFr : Fr,

--- a/kzg-bench/src/tests/eip_4844.rs
+++ b/kzg-bench/src/tests/eip_4844.rs
@@ -340,3 +340,75 @@ pub fn blob_to_kzg_commitment_test<
     assert_eq!(bytes, expected_bytes);
     
 }
+
+pub fn compute_aggregate_kzg_proof_test_empty<
+    TFr : Fr,
+    TG1: G1,
+    TG2: G2,
+    TPoly: Poly<TFr>,
+    TFFTSettings: FFTSettings<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly>
+>(
+    load_trusted_setup: &dyn Fn(&str) -> TKZGSettings, 
+    compute_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &TKZGSettings) -> TG1,
+    bytes_from_g1: &dyn Fn(&TG1) -> [u8; 48usize],
+) {
+
+    set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
+    let ts = load_trusted_setup("src/trusted_setups/trusted_setup.txt");
+
+    let empty_proof = compute_aggregate_kzg_proof(&[], &ts);
+
+    let mut expected_proof: [u8; 48] = [0; 48];
+    expected_proof[0] = 192;
+
+    assert_eq!(bytes_from_g1(&empty_proof), expected_proof);
+}
+
+pub fn verify_aggregate_kzg_proof_test_empty<
+    TFr : Fr,
+    TG1: G1,
+    TG2: G2,
+    TPoly: Poly<TFr>,
+    TFFTSettings: FFTSettings<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly>
+>(
+    load_trusted_setup: &dyn Fn(&str) -> TKZGSettings, 
+    compute_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &TKZGSettings) -> TG1,
+    verify_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &[TG1], &TG1, &TKZGSettings) -> bool,
+) {
+
+    set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
+    let ts = load_trusted_setup("src/trusted_setups/trusted_setup.txt");
+
+    assert!(verify_aggregate_kzg_proof(&[], &[], &compute_aggregate_kzg_proof(&[], &ts), &ts), "verify failed");
+}
+
+pub fn aggregate_proof_for_single_blob_test<
+    TFr : Fr,
+    TG1: G1,
+    TG2: G2,
+    TPoly: Poly<TFr>,
+    TFFTSettings: FFTSettings<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly>
+>(
+    load_trusted_setup: &dyn Fn(&str) -> TKZGSettings, 
+    blob_to_kzg_commitment: &dyn Fn(&[TFr], &TKZGSettings) -> TG1,
+    compute_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &TKZGSettings) -> TG1,
+    verify_aggregate_kzg_proof: &dyn Fn(&[Vec<TFr>], &[TG1], &TG1, &TKZGSettings) -> bool,
+) {
+    const BLOB_SIZE: u64 = 4096;
+
+    let mut rng = StdRng::seed_from_u64(0);
+
+    let blobs = [(0..BLOB_SIZE).map(|_| TFr::from_u64_arr(&rng.gen())).collect::<Vec<TFr>>()];
+
+    set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
+    let ts = load_trusted_setup("src/trusted_setups/trusted_setup.txt");
+
+    let commitments = blobs.iter().map(|blob| blob_to_kzg_commitment(blob, &ts)).collect::<Vec<TG1>>();
+    
+    let proof = compute_aggregate_kzg_proof(&blobs, &ts);
+
+    assert!(verify_aggregate_kzg_proof(&blobs, &commitments, &proof, &ts));
+}

--- a/kzg-bench/src/tests/fk20_proofs.rs
+++ b/kzg-bench/src/tests/fk20_proofs.rs
@@ -26,7 +26,7 @@ fn reverse_bits_limited(length: usize, value: usize) -> usize {
     value.reverse_bits() >> unused_bits
 }
 
-fn reverse_bit_order<T>(vals: &mut [T])
+pub fn reverse_bit_order<T>(vals: &mut [T])
 where
     T: Clone,
 {


### PR DESCRIPTION
Ported c-kzg [tests found in nodejs bindings](https://github.com/ethereum/c-kzg-4844/blob/1d3282895dae3dffc7fb0c65877fb039b5541ee0/bindings/node.js/test.ts) that deal with edge cases (mainly n < 2 in aggregate functions). 

Test verify_aggregate_kzg_proof_test_empty is commented out as it currently is [skipped in the nodejs bindings](https://github.com/ethereum/c-kzg-4844/blob/1d3282895dae3dffc7fb0c65877fb039b5541ee0/bindings/node.js/test.ts#L54).

Added benchmarks with varying numbers (4, 8, and 16) of blobs for compute_aggregate_kzg_proof.