### PR TITLE
Fix handling of infinity points in bgmw algorithm

### DIFF
--- a/arkworks4/tests/bls12_381.rs
+++ b/arkworks4/tests/bls12_381.rs
@@ -108,7 +108,6 @@ mod tests {
         );
     }
 
-    #[ignore = "TODO: handle infinity points"]
     #[test]
     pub fn g1_linear_combination_infinity_points_() {
         g1_linear_combination_infinity_points::<ArkFr, ArkG1, ArkFp, ArkG1Affine, ArkG1ProjAddAffine>(

--- a/arkworks5/tests/bls12_381.rs
+++ b/arkworks5/tests/bls12_381.rs
@@ -118,7 +118,6 @@ mod tests {
         );
     }
 
-    #[ignore = "TODO: handle infinity points"]
     #[test]
     pub fn g1_linear_combination_infinity_points_() {
         g1_linear_combination_infinity_points::<ArkFr, ArkG1, ArkFp, ArkG1Affine, ArkG1ProjAddAffine>(

--- a/kzg/src/msm/pippenger_utils.rs
+++ b/kzg/src/msm/pippenger_utils.rs
@@ -92,7 +92,7 @@ fn p1_dadd_affine<TG1: G1, TFp: G1Fp, TG1Affine: G1Affine<TG1, TFp>>(
     p2: &TG1Affine,
     subtract: bool, // Need to replace this somehow
 ) {
-    if type_is_zero(p2) != 0 {
+    if p2.is_zero() {
         return;
     } else if vec_is_zero(&out.zzz as *const TFp as *const u8, 2 * size_of::<TFp>()) != 0 {
         vec_copy(


### PR DESCRIPTION
This PR fixes bug in P1 point addition in XYZZ form, which is used in pippenger-based MSMs. This fixes infinity points tests for `arkworks4` and `arkworks5` backends. `mcl` is not fixed yet, needs separate fix.

This fix doesn't affect performance.